### PR TITLE
More improvements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,11 @@
 name = "TuringBenchmarking"
 uuid = "0db1332d-5c25-4deb-809f-459bc696f94f"
 authors = ["Tor Erlend Fjelde <tor.erlend95@gmail.com> and contributors"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+DynamicPPL = "366bfd00-2699-11ea-058f-f148b4cae6d8"
 LogDensityProblems = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
 LogDensityProblemsAD = "996a588d-648d-4e1f-a8f0-a84b347e47b1"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
@@ -15,19 +16,20 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 [weakdeps]
 BridgeStan = "c88b6f0a-829e-4b0b-94b7-f06ab5908f5a"
 
+[extensions]
+TuringBenchmarkingBridgeStanExt = "BridgeStan"
+
 [compat]
 BenchmarkTools = "1"
 BridgeStan = "2"
+DynamicPPL = "0.23"
 LogDensityProblems = "2"
 LogDensityProblemsAD = "1"
 Requires = "1"
 ReverseDiff = "1.14"
-Turing = "0.23, 0.24, 0.29"
+Turing = "0.29"
 Zygote = "0.6"
 julia = "1.6"
-
-[extensions]
-TuringBenchmarkingBridgeStanExt = "BridgeStan"
 
 [extras]
 BridgeStan = "c88b6f0a-829e-4b0b-94b7-f06ab5908f5a"

--- a/src/TuringBenchmarking.jl
+++ b/src/TuringBenchmarking.jl
@@ -86,7 +86,8 @@ end
 Create default benchmark suite for `model`.
 
 # Keyword arguments
-- `adbackends`: a collection of adbackends to use. Defaults to `$(DEFAULT_ADBACKENDS)`.
+- `adbackends`: a collection of adbackends to use, specified either as a
+  `Turing.Essential.ADBackend` or using a `Symbol`. Defaults to `$(DEFAULT_ADBACKENDS)`.
 - `run_once=true`: if `true`, the body of each benchmark will be run once to avoid
   compilation to be included in the timings (this may occur if compilation runs
   longer than the allowed time limit).

--- a/src/TuringBenchmarking.jl
+++ b/src/TuringBenchmarking.jl
@@ -20,10 +20,10 @@ export benchmark_model, make_turing_suite, @tagged
 
 # Don't include `TrackerAD` because it's never going to win.
 const DEFAULT_ADBACKENDS = [
-    ForwardDiffAD{}(Turing.Essential.CHUNKSIZE[]), # chunksize=40
-    ZygoteAD(),
+    ForwardDiffAD{Turing.Essential.CHUNKSIZE[]}(), # chunksize=40
     ReverseDiffAD{false}(), # rdcache=false
-    ReverseDiffAD{true}()   # rdcache=false
+    ReverseDiffAD{true}(),  # rdcache=false
+    ZygoteAD(),
 ]
 
 backend_label(::ForwardDiffAD) = "ForwardDiff"
@@ -67,7 +67,6 @@ function benchmark_model(
     varinfo::DynamicPPL.AbstractVarInfo = DynamicPPL.VarInfo(model),
     sampler::Union{AbstractMCMC.AbstractSampler,Nothing} = nothing,
     context::DynamicPPL.AbstractContext = DynamicPPL.DefaultContext(),
-    verbose=true,
     kwargs...
 )
     suite = make_turing_suite(
@@ -80,7 +79,7 @@ function benchmark_model(
         context,
         kwargs...
     )
-    return run(suite; verbose=verbose, kwargs...)
+    return run(suite; kwargs...)
 end
 
 """

--- a/src/TuringBenchmarking.jl
+++ b/src/TuringBenchmarking.jl
@@ -41,7 +41,9 @@ const SYMBOL_TO_BACKEND = Dict(
 )
 
 to_backend(x) = error("Unknown backend: $x")
-to_backend(x::Symbol) = get(SYMBOL_TO_BACKEND, lowercase(x), error("Unknown backend: $x"))
+to_backend(x::Symbol) = get(
+    SYMBOL_TO_BACKEND, Symbol(lowercase(string(x))), error("Unknown backend: $x")
+)
 to_backend(x::Turing.Essential.ADBackend) = x
 
 """

--- a/src/TuringBenchmarking.jl
+++ b/src/TuringBenchmarking.jl
@@ -41,10 +41,12 @@ const SYMBOL_TO_BACKEND = Dict(
 )
 
 to_backend(x) = error("Unknown backend: $x")
-to_backend(x::Symbol) = get(
-    SYMBOL_TO_BACKEND, Symbol(lowercase(string(x))), error("Unknown backend: $x")
-)
 to_backend(x::Turing.Essential.ADBackend) = x
+function to_backend(x::Union{AbstractString,Symbol})
+    k = Symbol(lowercase(string(x)))
+    haskey(SYMBOL_TO_BACKEND, k) || error("Unknown backend: $x")
+    return SYMBOL_TO_BACKEND[k]
+end
 
 """
     benchmark_model(model::Turing.Model; suite_kwargs..., kwargs...)

--- a/src/TuringBenchmarking.jl
+++ b/src/TuringBenchmarking.jl
@@ -20,8 +20,7 @@ export benchmark_model, make_turing_suite, @tagged
 
 # Don't include `TrackerAD` because it's never going to win.
 const DEFAULT_ADBACKENDS = [
-    ForwardDiffAD{40}(),    # chunksize=40
-    ForwardDiffAD{100}(),   # chunksize=100
+    ForwardDiffAD{}(Turing.Essential.CHUNKSIZE[]), # chunksize=40
     ZygoteAD(),
     ReverseDiffAD{false}(), # rdcache=false
     ReverseDiffAD{true}()   # rdcache=false
@@ -33,7 +32,7 @@ backend_label(::ZygoteAD) = "Zygote"
 backend_label(::TrackerAD) = "Tracker"
 
 const SYMBOL_TO_BACKEND = Dict(
-    :forwarddiff => ForwardDiffAD{40}(),
+    :forwarddiff => ForwardDiffAD{Turing.Essential.CHUNKSIZE[]}(),
     :reversediff => ReverseDiffAD{false}(),
     :reversediff_compiled => ReverseDiffAD{true}(),
     :zygote => ZygoteAD(),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,65 +6,118 @@ using Test
 using Zygote: Zygote
 using ReverseDiff: ReverseDiff
 
+# These should be ordered (ascendingly) by runtime.
+ADBACKENDS = [
+    TuringBenchmarking.ForwardDiffAD{40}(),
+    TuringBenchmarking.ReverseDiffAD{true}(),
+    TuringBenchmarking.ReverseDiffAD{false}(),
+    TuringBenchmarking.ZygoteAD(),
+]
+
 @testset "TuringBenchmarking.jl" begin
-    ### Setup ###
-    function sim(I, P)
-        yvec = Vector{Int}(undef, I * P)
-        ivec = similar(yvec)
-        pvec = similar(yvec)
+    @testset "Item-Response model" begin
+        ### Setup ###
+        function sim(I, P)
+            yvec = Vector{Int}(undef, I * P)
+            ivec = similar(yvec)
+            pvec = similar(yvec)
 
-        beta = rand(Normal(), I)
-        theta = rand(Normal(), P)
+            beta = rand(Normal(), I)
+            theta = rand(Normal(), P)
 
-        n = 0
-        for i in 1:I, p in 1:P
-            n += 1
-            ivec[n] = i
-            pvec[n] = p
-            yvec[n] = rand(BernoulliLogit(theta[p] - beta[i]))
+            n = 0
+            for i in 1:I, p in 1:P
+                n += 1
+                ivec[n] = i
+                pvec[n] = p
+                yvec[n] = rand(BernoulliLogit(theta[p] - beta[i]))
+            end
+
+            return yvec, ivec, pvec, theta, beta
         end
 
-        return yvec, ivec, pvec, theta, beta
+        P = 10
+        y, i, p, _, _ = sim(20, P)
+
+        ### Turing ###
+        # performant model
+        @model function irt(y, i, p; I=maximum(i), P=maximum(p))
+            theta ~ filldist(Normal(), P)
+            beta ~ filldist(Normal(), I)
+            Turing.@addlogprob! sum(logpdf.(BernoulliLogit.(theta[p] - beta[i]), y))
+
+            return (; theta, beta)
+        end
+
+        # Instantiate
+        model = irt(y, i, p)
+
+        # Make the benchmark suite.
+        @testset "$(nameof(typeof(varinfo)))" for varinfo in [
+            DynamicPPL.VarInfo(model),
+            DynamicPPL.SimpleVarInfo(model),
+        ]
+            suite = TuringBenchmarking.make_turing_suite(
+                model;
+                adbackends=ADBACKENDS,
+                varinfo=varinfo
+            )
+            results = run(suite, verbose=true, evals=1, samples=2)
+
+            # TODO: Is there a better way to test these?
+            for (i, adbackend) in enumerate(ADBACKENDS)
+                adbackend_string = "$(adbackend)"
+                results_backend = results[@tagged adbackend_string]
+                # Each AD backend should have two results.
+                @test length(leaves(results_backend)) == 2
+                # It should be under the "gradient" section.
+                @test haskey(results_backend, "gradient")
+                # It should have one tagged "linked" and one "standard"
+                @test length(leaves(results_backend[@tagged "linked"])) == 1
+                @test length(leaves(results_backend[@tagged "standard"])) == 1
+            end
+        end
     end
 
-    P = 10
-    y, i, p, _, _ = sim(20, P)
+    @testset "Model with mutation" begin
+        @model function demo_with_mutation(::Type{TV}=Vector{Float64}) where {TV}
+            x = TV(undef, 2)
+            x[1] ~ Normal()
+            x[2] ~ Normal()
+            return x
+        end
+        model = demo_with_mutation()
 
-    ### Turing ###
-    # performant model
-    @model function irt(y, i, p; I=maximum(i), P=maximum(p))
-        theta ~ filldist(Normal(), P)
-        beta ~ filldist(Normal(), I)
-        Turing.@addlogprob! sum(logpdf.(BernoulliLogit.(theta[p] - beta[i]), y))
+        # Make the benchmark suite.
+        @testset "$(nameof(typeof(varinfo)))" for varinfo in [
+            DynamicPPL.VarInfo(model),
+            DynamicPPL.SimpleVarInfo(x=randn(2)),
+            DynamicPPL.SimpleVarInfo(DynamicPPL.OrderedDict(@varname(x) => randn(2))),
+        ]
+            suite = TuringBenchmarking.make_turing_suite(
+                model;
+                adbackends=ADBACKENDS,
+                varinfo=varinfo
+            )
+            results = run(suite, verbose=true, evals=1, samples=2)
 
-        return (; theta, beta)
-    end
-
-    # Instantiate
-    model = irt(y, i, p)
-
-    # Make the benchmark suite.
-    # These should be ordered (ascendingly) by runtime.
-    adbackends = [
-        TuringBenchmarking.ForwardDiffAD{40}(),
-        TuringBenchmarking.ReverseDiffAD{true}(),
-        TuringBenchmarking.ReverseDiffAD{false}(),
-        TuringBenchmarking.ZygoteAD(),
-    ]
-    suite = TuringBenchmarking.make_turing_suite(
-        model,
-        adbackends=adbackends
-    )
-    results = run(suite)
-
-    # TODO: Is there a better way to test these?
-    for (i, adbackend) in enumerate(adbackends)
-        @test haskey(suite["not_linked"], "$(adbackend)")
-        @test haskey(suite["linked"], "$(adbackend)")
-
-        if i < length(adbackends)
-            @test median(results["not_linked"]["$(adbackend)"]) ≤ median(results["not_linked"]["$(adbackends[i+1])"])
-            @test median(results["linked"]["$(adbackend)"]) ≤ median(results["linked"]["$(adbackends[i+1])"])
+            for (i, adbackend) in enumerate(ADBACKENDS)
+                adbackend_string = "$(adbackend)"
+                results_backend = results[@tagged adbackend_string]
+                if adbackend isa TuringBenchmarking.ZygoteAD
+                    # Zygote.jl should fail, i.e. return an empty suite.
+                    @test length(leaves(results_backend)) == 0
+                else
+                    # Each AD backend should have two results.
+                    @test length(leaves(results_backend)) == 2
+                    # It should be under the "gradient" section.
+                    @test haskey(results_backend, "gradient")
+                    # It should have one tagged "linked" and one "standard"
+                    @test length(leaves(results_backend[@tagged "linked"])) == 1
+                    @test length(leaves(results_backend[@tagged "standard"])) == 1
+                end
+            end
         end
     end
 end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,9 +35,7 @@ ADBACKENDS = [
 
             return yvec, ivec, pvec, theta, beta
         end
-
-        P = 10
-        y, i, p, _, _ = sim(20, P)
+        y, i, p, _, _ = sim(20, 10)
 
         ### Turing ###
         # performant model
@@ -64,7 +62,6 @@ ADBACKENDS = [
             )
             results = run(suite, verbose=true, evals=1, samples=2)
 
-            # TODO: Is there a better way to test these?
             for (i, adbackend) in enumerate(ADBACKENDS)
                 adbackend_string = "$(adbackend)"
                 results_backend = results[@tagged adbackend_string]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,12 +12,7 @@ BenchmarkTools.DEFAULT_PARAMETERS.evals = 1
 BenchmarkTools.DEFAULT_PARAMETERS.samples = 2
 
 # These should be ordered (ascendingly) by runtime.
-ADBACKENDS = [
-    TuringBenchmarking.ForwardDiffAD{40}(),
-    TuringBenchmarking.ReverseDiffAD{true}(),
-    TuringBenchmarking.ReverseDiffAD{false}(),
-    TuringBenchmarking.ZygoteAD(),
-]
+ADBACKENDS = TuringBenchmarking.DEFAULT_ADBACKENDS
 
 @testset "TuringBenchmarking.jl" begin
     @testset "Item-Response model" begin
@@ -68,7 +63,7 @@ ADBACKENDS = [
             )
             results = run(suite, verbose=true)
 
-            for (i, adbackend) in enumerate(ADBACKENDS)
+            @testset "$adbackend" for (i, adbackend) in enumerate(ADBACKENDS)
                 adbackend_string = "$(adbackend)"
                 results_backend = results[@tagged adbackend_string]
                 # Each AD backend should have two results.
@@ -90,7 +85,7 @@ ADBACKENDS = [
             )
             results = run(suite, verbose=true)
 
-            for (i, adbackend) in enumerate(ADBACKENDS)
+            @testset "$adbackend" for (i, adbackend) in enumerate(ADBACKENDS)
                 adbackend_string = "$(adbackend)"
                 results_backend = results[@tagged adbackend_string]
                 # Each AD backend should have two results.
@@ -127,7 +122,7 @@ ADBACKENDS = [
             )
             results = run(suite, verbose=true)
 
-            for (i, adbackend) in enumerate(ADBACKENDS)
+            @testset "$adbackend" for (i, adbackend) in enumerate(ADBACKENDS)
                 adbackend_string = "$(adbackend)"
                 results_backend = results[@tagged adbackend_string]
                 if adbackend isa TuringBenchmarking.ZygoteAD

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,11 @@ using Test
 using Zygote: Zygote
 using ReverseDiff: ReverseDiff
 
+# Just make things run a bit faster.
+BenchmarkTools.DEFAULT_PARAMETERS.seconds = 1
+BenchmarkTools.DEFAULT_PARAMETERS.evals = 1
+BenchmarkTools.DEFAULT_PARAMETERS.samples = 2
+
 # These should be ordered (ascendingly) by runtime.
 ADBACKENDS = [
     TuringBenchmarking.ForwardDiffAD{40}(),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,7 +66,7 @@ ADBACKENDS = [
                 varinfo=varinfo,
                 check_grads=true,
             )
-            results = run(suite, verbose=true, evals=1, samples=2)
+            results = run(suite, verbose=true)
 
             for (i, adbackend) in enumerate(ADBACKENDS)
                 adbackend_string = "$(adbackend)"
@@ -88,7 +88,7 @@ ADBACKENDS = [
                 adbackends=[:forwarddiff, :reversediff, :reversediff_compiled, :zygote],
                 varinfo=varinfo,
             )
-            results = run(suite, verbose=true, evals=1, samples=2)
+            results = run(suite, verbose=true)
 
             for (i, adbackend) in enumerate(ADBACKENDS)
                 adbackend_string = "$(adbackend)"
@@ -125,7 +125,7 @@ ADBACKENDS = [
                 adbackends=ADBACKENDS,
                 varinfo=varinfo
             )
-            results = run(suite, verbose=true, evals=1, samples=2)
+            results = run(suite, verbose=true)
 
             for (i, adbackend) in enumerate(ADBACKENDS)
                 adbackend_string = "$(adbackend)"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,7 +58,8 @@ ADBACKENDS = [
             suite = TuringBenchmarking.make_turing_suite(
                 model;
                 adbackends=ADBACKENDS,
-                varinfo=varinfo
+                varinfo=varinfo,
+                check_grads=true,
             )
             results = run(suite, verbose=true, evals=1, samples=2)
 
@@ -75,6 +76,7 @@ ADBACKENDS = [
             end
         end
     end
+
 
     @testset "Model with mutation" begin
         @model function demo_with_mutation(::Type{TV}=Vector{Float64}) where {TV}


### PR DESCRIPTION
- Shuffled around the benchmark suite, so the structure is now (IMO) better + we're now using tags.
- Added `benchmark_model` which builds the suite and executes it.
- Export `benchmark_model`, `make_turing_suite`, and `BenchmarkTools.@tagged`
- Simple conversion from `Symbol` to `ADBackend` to make it a bit easier for users