### PR TITLE
Depend on DynamicPPL.jl instead of Turing.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TuringBenchmarking"
 uuid = "0db1332d-5c25-4deb-809f-459bc696f94f"
 authors = ["Tor Erlend Fjelde <tor.erlend95@gmail.com> and contributors"]
-version = "0.4.0"
+version = "0.5.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.4.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
+AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 DynamicPPL = "366bfd00-2699-11ea-058f-f148b4cae6d8"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -14,7 +15,6 @@ LogDensityProblemsAD = "996a588d-648d-4e1f-a8f0-a84b347e47b1"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
-Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [weakdeps]
@@ -25,15 +25,15 @@ TuringBenchmarkingBridgeStanExt = "BridgeStan"
 
 [compat]
 ADTypes = "0.2"
+AbstractMCMC = "5"
 BenchmarkTools = "1"
 BridgeStan = "2"
-DynamicPPL = "0.23, 0.24"
+DynamicPPL = "0.24.7"
 LogDensityProblems = "2"
 LogDensityProblemsAD = "1"
 PrettyTables = "2"
 Requires = "1"
 ReverseDiff = "1.14"
-Turing = "0.30"
 Zygote = "0.6"
 julia = "1.6"
 

--- a/src/TuringBenchmarking.jl
+++ b/src/TuringBenchmarking.jl
@@ -6,11 +6,12 @@ using BenchmarkTools
 using LogDensityProblems
 using LogDensityProblemsAD
 
-using Turing
+using DynamicPPL
 using ADTypes
 
 using PrettyTables: PrettyTables
 
+using AbstractMCMC: AbstractMCMC
 using DynamicPPL: DynamicPPL
 
 # Load some the default backends to trigger conditional loading.

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,8 +1,10 @@
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+DistributionsAD = "ced4e74d-a319-5a8a-b0ac-84af2272839c"
+DynamicPPL = "366bfd00-2699-11ea-058f-f148b4cae6d8"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using TuringBenchmarking
 using BenchmarkTools
-using Turing
+using DynamicPPL, Distributions, DistributionsAD
 using Test
 using ADTypes
 
@@ -17,7 +17,7 @@ ADBACKENDS = TuringBenchmarking.DEFAULT_ADBACKENDS
 
 @testset "TuringBenchmarking.jl" begin
     @testset "Item-Response model" begin
-        ### Setup ###
+        # Simulate data.
         function sim(I, P)
             yvec = Vector{Int}(undef, I * P)
             ivec = similar(yvec)
@@ -38,12 +38,11 @@ ADBACKENDS = TuringBenchmarking.DEFAULT_ADBACKENDS
         end
         y, i, p, _, _ = sim(5, 3)
 
-        ### Turing ###
-        # performant model
+        # Performant model.
         @model function irt(y, i, p; I=maximum(i), P=maximum(p))
             theta ~ filldist(Normal(), P)
             beta ~ filldist(Normal(), I)
-            Turing.@addlogprob! sum(logpdf.(BernoulliLogit.(theta[p] - beta[i]), y))
+            DynamicPPL.@addlogprob! sum(logpdf.(BernoulliLogit.(theta[p] - beta[i]), y))
 
             return (; theta, beta)
         end


### PR DESCRIPTION
Since DynamicPPL.jl v0.24.7, we no longer have to rely on Turing.jl for AD-related stuff. Hence we can drop explicit dependence on Turing.jl, which reduces the number of deps quite drastically.